### PR TITLE
Ignore routes that do not have templates but have sub-routes.

### DIFF
--- a/src/util/loadFilesystemRoutes.js
+++ b/src/util/loadFilesystemRoutes.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const routesTable = require('routes-table');
+const tryRequire = require('try-require');
 
 module.exports = (project) => {
   const rootDir = project.getDir();
@@ -22,13 +23,13 @@ module.exports = (project) => {
       if (template) {
         delete route.template;
       } else {
-        try {
-          templatePath = path.join(route.__dirname, 'index.marko');
-          template = require(templatePath);
-        } catch (e) {
-          if (e.code !== 'MODULE_NOT_FOUND' || !e.message.includes(templatePath)) {
-            throw e;
-          }
+        templatePath = path.join(route.__dirname, 'index.marko');
+        template = tryRequire(templatePath);
+
+        // Ignore a route that does not have a template, but has a sub-routes
+        if (!template && route.subRoutesExist) {
+          return false;
+        } else if (!template && !route.subRoutesExist) {
           throw new Error(
             'A route must contain a `route.js` file that exports a template ' +
             'or handler, or the route must contain an `index.marko` file. \n' +


### PR DESCRIPTION
Relies on `routes-table` PR: https://github.com/mlrawlings/routes-table/pull/4 